### PR TITLE
💾 Setup Room Database for Favorite Locations

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     kotlin("plugin.serialization") version "2.0.0"
+    kotlin("kapt")
 }
 
 android {
@@ -72,6 +73,11 @@ dependencies {
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
+    
+    // Room Database
+    implementation("androidx.room:room-runtime:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
+    kapt("androidx.room:room-compiler:2.6.1")
     
     // Testing
     testImplementation(libs.junit)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
+        android:name=".WeatherApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/example/locationweatherforcast/WeatherApplication.kt
+++ b/app/src/main/java/com/example/locationweatherforcast/WeatherApplication.kt
@@ -1,0 +1,13 @@
+package com.example.locationweatherforcast
+
+import android.app.Application
+import com.example.locationweatherforcast.data.database.AppDatabase
+
+class WeatherApplication : Application() {
+    
+    val database by lazy { AppDatabase.getDatabase(this) }
+    
+    override fun onCreate() {
+        super.onCreate()
+    }
+}

--- a/app/src/main/java/com/example/locationweatherforcast/data/database/AppDatabase.kt
+++ b/app/src/main/java/com/example/locationweatherforcast/data/database/AppDatabase.kt
@@ -1,0 +1,33 @@
+package com.example.locationweatherforcast.data.database
+
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import android.content.Context
+
+@Database(
+    entities = [FavoriteLocation::class],
+    version = 1,
+    exportSchema = false
+)
+abstract class AppDatabase : RoomDatabase() {
+    
+    abstract fun favoriteLocationDao(): FavoriteLocationDao
+    
+    companion object {
+        @Volatile
+        private var INSTANCE: AppDatabase? = null
+        
+        fun getDatabase(context: Context): AppDatabase {
+            return INSTANCE ?: synchronized(this) {
+                val instance = Room.databaseBuilder(
+                    context.applicationContext,
+                    AppDatabase::class.java,
+                    "weather_app_database"
+                ).build()
+                INSTANCE = instance
+                instance
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/locationweatherforcast/data/database/FavoriteLocation.kt
+++ b/app/src/main/java/com/example/locationweatherforcast/data/database/FavoriteLocation.kt
@@ -1,0 +1,14 @@
+package com.example.locationweatherforcast.data.database
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "favorite_locations")
+data class FavoriteLocation(
+    @PrimaryKey val id: String,
+    val name: String,
+    val latitude: Double,
+    val longitude: Double,
+    val createdAt: Long,
+    val order: Int
+)

--- a/app/src/main/java/com/example/locationweatherforcast/data/database/FavoriteLocationDao.kt
+++ b/app/src/main/java/com/example/locationweatherforcast/data/database/FavoriteLocationDao.kt
@@ -1,0 +1,35 @@
+package com.example.locationweatherforcast.data.database
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface FavoriteLocationDao {
+    
+    @Query("SELECT * FROM favorite_locations ORDER BY `order` ASC")
+    fun getAllFavoriteLocations(): Flow<List<FavoriteLocation>>
+    
+    @Query("SELECT * FROM favorite_locations WHERE id = :id")
+    suspend fun getFavoriteLocationById(id: String): FavoriteLocation?
+    
+    @Query("SELECT COUNT(*) FROM favorite_locations")
+    suspend fun getCount(): Int
+    
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertFavoriteLocation(location: FavoriteLocation)
+    
+    @Update
+    suspend fun updateFavoriteLocation(location: FavoriteLocation)
+    
+    @Delete
+    suspend fun deleteFavoriteLocation(location: FavoriteLocation)
+    
+    @Query("DELETE FROM favorite_locations WHERE id = :id")
+    suspend fun deleteFavoriteLocationById(id: String)
+    
+    @Query("DELETE FROM favorite_locations")
+    suspend fun deleteAllFavoriteLocations()
+    
+    @Query("UPDATE favorite_locations SET `order` = :newOrder WHERE id = :id")
+    suspend fun updateOrder(id: String, newOrder: Int)
+}


### PR DESCRIPTION
## Summary
• お気に入り場所の永続化のためのRoom Databaseセットアップを完了
• 最大5箇所のお気に入り場所をサポートするデータベーススキーマを実装

## Changes
- Room依存関係とkaptプラグインを追加
- `FavoriteLocation`エンティティ（id, name, latitude, longitude, createdAt, order）を作成
- 完全なCRUD操作を持つ`FavoriteLocationDao`を実装
- Room設定済みの`AppDatabase`クラスを作成
- データベース初期化用の`WeatherApplication`クラスを作成
- AndroidManifest.xmlにアプリケーションクラスを登録

## Test plan
- [x] `./gradlew assembleDebug`でビルドが成功することを確認
- [x] Room Databaseの設定が正しく動作することを確認
- [x] すべてのエンティティ、Dao、Databaseクラスが適切に実装されていることを確認

Implements #2

🤖 Generated with [Claude Code](https://claude.ai/code)