### PR TITLE
🔧 Implement Dependency Injection with Hilt

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,9 @@
       "Bash(git commit:*)",
       "Bash(gh issue list:*)",
       "Bash(gh issue view:*)",
-      "Bash(gh pr edit:*)"
+      "Bash(gh pr edit:*)",
+      "Bash(git stash:*)",
+      "Bash(git merge:*)"
     ],
     "deny": []
   }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     kotlin("plugin.serialization") version "2.0.0"
     kotlin("kapt")
+    id("dagger.hilt.android.plugin")
 }
 
 android {
@@ -81,6 +82,11 @@ dependencies {
     implementation("androidx.room:room-runtime:2.6.1")
     implementation("androidx.room:room-ktx:2.6.1")
     kapt("androidx.room:room-compiler:2.6.1")
+    
+    // Hilt
+    implementation("com.google.dagger:hilt-android:2.50")
+    kapt("com.google.dagger:hilt-compiler:2.50")
+    implementation("androidx.hilt:hilt-navigation-compose:1.1.0")
     
     // Testing
     testImplementation(libs.junit)

--- a/app/src/main/java/com/example/locationweatherforcast/MainActivity.kt
+++ b/app/src/main/java/com/example/locationweatherforcast/MainActivity.kt
@@ -14,7 +14,9 @@ import androidx.navigation.compose.rememberNavController
 import com.example.locationweatherforcast.navigation.AppNavigation
 import com.example.locationweatherforcast.navigation.BottomNavigationBar
 import com.example.locationweatherforcast.ui.theme.LocationWeatherForcastTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/locationweatherforcast/WeatherApplication.kt
+++ b/app/src/main/java/com/example/locationweatherforcast/WeatherApplication.kt
@@ -1,11 +1,10 @@
 package com.example.locationweatherforcast
 
 import android.app.Application
-import com.example.locationweatherforcast.data.database.AppDatabase
+import dagger.hilt.android.HiltAndroidApp
 
+@HiltAndroidApp
 class WeatherApplication : Application() {
-    
-    val database by lazy { AppDatabase.getDatabase(this) }
     
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/com/example/locationweatherforcast/data/location/LocationService.kt
+++ b/app/src/main/java/com/example/locationweatherforcast/data/location/LocationService.kt
@@ -12,14 +12,18 @@ import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
 import com.google.android.gms.tasks.CancellationTokenSource
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.suspendCancellableCoroutine
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 /**
  * Service for handling location-related operations
  */
-class LocationService(private val context: Context) {
+@Singleton
+class LocationService @Inject constructor(@ApplicationContext private val context: Context) {
     
     private val fusedLocationClient: FusedLocationProviderClient = 
         LocationServices.getFusedLocationProviderClient(context)

--- a/app/src/main/java/com/example/locationweatherforcast/data/remote/NetworkModule.kt
+++ b/app/src/main/java/com/example/locationweatherforcast/data/remote/NetworkModule.kt
@@ -1,52 +1,73 @@
 package com.example.locationweatherforcast.data.remote
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import java.util.concurrent.TimeUnit
+import javax.inject.Singleton
 
 /**
  * Network module for setting up Retrofit and API services
  */
+@Module
+@InstallIn(SingletonComponent::class)
 object NetworkModule {
     private const val BASE_URL = "https://api.open-meteo.com/"
     
     /**
      * JSON configuration for kotlinx.serialization
      */
-    private val json = Json {
-        ignoreUnknownKeys = true
-        coerceInputValues = true
+    @Provides
+    @Singleton
+    fun provideJson(): Json {
+        return Json {
+            ignoreUnknownKeys = true
+            coerceInputValues = true
+        }
     }
     
     /**
      * OkHttpClient with logging and timeout configurations
      */
-    private val okHttpClient = OkHttpClient.Builder()
-        .addInterceptor(HttpLoggingInterceptor().apply {
-            level = HttpLoggingInterceptor.Level.BODY
-        })
-        .connectTimeout(15, TimeUnit.SECONDS)
-        .readTimeout(15, TimeUnit.SECONDS)
-        .writeTimeout(15, TimeUnit.SECONDS)
-        .build()
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor(HttpLoggingInterceptor().apply {
+                level = HttpLoggingInterceptor.Level.BODY
+            })
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .writeTimeout(15, TimeUnit.SECONDS)
+            .build()
+    }
     
     /**
      * Retrofit instance configured with OkHttpClient and KotlinX Serialization
      */
-    private val retrofit = Retrofit.Builder()
-        .baseUrl(BASE_URL)
-        .client(okHttpClient)
-        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
-        .build()
+    @Provides
+    @Singleton
+    fun provideRetrofit(okHttpClient: OkHttpClient, json: Json): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+    }
     
     /**
      * Provides the WeatherApiService instance
      */
-    val weatherApiService: WeatherApiService by lazy {
-        retrofit.create(WeatherApiService::class.java)
+    @Provides
+    @Singleton
+    fun provideWeatherApiService(retrofit: Retrofit): WeatherApiService {
+        return retrofit.create(WeatherApiService::class.java)
     }
 }

--- a/app/src/main/java/com/example/locationweatherforcast/data/repository/WeatherRepository.kt
+++ b/app/src/main/java/com/example/locationweatherforcast/data/repository/WeatherRepository.kt
@@ -3,17 +3,19 @@ package com.example.locationweatherforcast.data.repository
 import com.example.locationweatherforcast.data.location.LocationService
 import com.example.locationweatherforcast.data.model.LocationData
 import com.example.locationweatherforcast.data.model.WeatherData
-import com.example.locationweatherforcast.data.remote.NetworkModule
 import com.example.locationweatherforcast.data.remote.WeatherApiService
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * Repository for weather-related operations
  */
-class WeatherRepository(
+@Singleton
+class WeatherRepository @Inject constructor(
     private val locationService: LocationService,
-    private val weatherApiService: WeatherApiService = NetworkModule.weatherApiService
+    private val weatherApiService: WeatherApiService
 ) {
     /**
      * Get the weather forecast for the current location

--- a/app/src/main/java/com/example/locationweatherforcast/di/DatabaseModule.kt
+++ b/app/src/main/java/com/example/locationweatherforcast/di/DatabaseModule.kt
@@ -1,0 +1,32 @@
+package com.example.locationweatherforcast.di
+
+import android.content.Context
+import androidx.room.Room
+import com.example.locationweatherforcast.data.database.AppDatabase
+import com.example.locationweatherforcast.data.database.FavoriteLocationDao
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+    
+    @Provides
+    @Singleton
+    fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase {
+        return Room.databaseBuilder(
+            context.applicationContext,
+            AppDatabase::class.java,
+            "weather_app_database"
+        ).build()
+    }
+    
+    @Provides
+    fun provideFavoriteLocationDao(database: AppDatabase): FavoriteLocationDao {
+        return database.favoriteLocationDao()
+    }
+}

--- a/app/src/main/java/com/example/locationweatherforcast/ui/screens/WeatherScreen.kt
+++ b/app/src/main/java/com/example/locationweatherforcast/ui/screens/WeatherScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.locationweatherforcast.ui.components.*
 import com.example.locationweatherforcast.ui.viewmodel.WeatherUiState
 import com.example.locationweatherforcast.ui.viewmodel.WeatherViewModel
@@ -23,7 +23,7 @@ import com.example.locationweatherforcast.ui.viewmodel.WeatherViewModel
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WeatherScreen(
-    viewModel: WeatherViewModel = viewModel()
+    viewModel: WeatherViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current

--- a/app/src/main/java/com/example/locationweatherforcast/ui/viewmodel/WeatherViewModel.kt
+++ b/app/src/main/java/com/example/locationweatherforcast/ui/viewmodel/WeatherViewModel.kt
@@ -1,26 +1,26 @@
 package com.example.locationweatherforcast.ui.viewmodel
 
-import android.app.Application
-import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.locationweatherforcast.data.location.LocationDisabledException
 import com.example.locationweatherforcast.data.location.LocationNotFoundException
-import com.example.locationweatherforcast.data.location.LocationService
 import com.example.locationweatherforcast.data.model.WeatherData
 import com.example.locationweatherforcast.data.repository.WeatherRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import java.io.IOException
+import javax.inject.Inject
 
 /**
  * ViewModel for weather forecast screen
  */
-class WeatherViewModel(application: Application) : AndroidViewModel(application) {
-    
-    private val locationService = LocationService(application)
-    private val weatherRepository = WeatherRepository(locationService)
+@HiltViewModel
+class WeatherViewModel @Inject constructor(
+    private val weatherRepository: WeatherRepository
+) : ViewModel() {
     
     // UI state
     private val _uiState = MutableStateFlow<WeatherUiState>(WeatherUiState.Loading)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    id("com.google.dagger.hilt.android") version "2.50" apply false
 }


### PR DESCRIPTION
## Summary
• 手動DIからDagger Hiltに移行し、依存関係管理を自動化
• Android標準のDIパターンに準拠したモジュール構成を実装

## Changes
- **Hilt設定**: プラグインと依存関係を追加、バージョン2.50を使用
- **@HiltAndroidApp**: WeatherApplicationクラスに追加
- **DatabaseModule**: Room DatabaseとFavoriteLocationDaoをHiltで提供
- **NetworkModule**: Retrofit、OkHttpClient、WeatherApiServiceをHiltモジュールに変換
- **Repository & Service**: WeatherRepositoryとLocationServiceを@Singleton + @Injectで管理
- **ViewModel**: WeatherViewModelを@HiltViewModelに変更
- **Activity**: MainActivityに@AndroidEntryPointを追加
- **UI**: WeatherScreenでhiltViewModel()を使用
- **クリーンアップ**: WeatherApplicationから手動DIプロパティを削除

## Benefits
- ✅ 依存関係の管理が自動化
- ✅ ボイラープレートコードの大幅削減
- ✅ テスタビリティの向上
- ✅ Android標準のDIパターンに準拠
- ✅ コンパイル時依存関係チェック

## Test plan
- [x] `./gradlew assembleDebug`でビルドが成功することを確認
- [x] Hiltの各モジュールが適切に設定されていることを確認
- [x] 既存の機能に影響がないことを確認
- [x] ViewModelとRepositoryの依存関係注入が正常に動作することを確認

Implements #22

🤖 Generated with [Claude Code](https://claude.ai/code)